### PR TITLE
updates to allow building ecp-proxy-apps

### DIFF
--- a/var/spack/repos/builtin/packages/ecp-proxy-apps/package.py
+++ b/var/spack/repos/builtin/packages/ecp-proxy-apps/package.py
@@ -35,7 +35,7 @@ class EcpProxyApps(BundlePackage):
     depends_on("mlperf-deepcam@master", when="+ml @4.0:")
 
     # Added with release 4.0
-    depends_on("miniamr@1.6.4", when="@4.0:")
+    depends_on("miniamr@master", when="@4.0:")
 
     # Added with release 3.0
     depends_on("miniamr@1.4.4", when="@3.0:3.1")
@@ -49,7 +49,7 @@ class EcpProxyApps(BundlePackage):
     # Added with release 2.0
     depends_on("ember@1.0.0", when="@2.0:")
     depends_on("miniqmc@0.4.0", when="@2.0:")
-    depends_on("minivite@1.0", when="@2.0:")
+    depends_on("minivite@develop", when="@2.0:")
     depends_on("picsarlite@0.1", when="@2.0:")
     depends_on("thornado-mini@1.0", when="@2.0:")
 

--- a/var/spack/repos/builtin/packages/ember/package.py
+++ b/var/spack/repos/builtin/packages/ember/package.py
@@ -29,7 +29,7 @@ class Ember(MakefilePackage):
         file = open("Makefile", "w")
 
         file.write("CC = mpicc\n")
-        file.write("CFLAGS = -O3 -std=c99\n")
+        file.write("CFLAGS = -O3 -std=c99 -D_POSIX_C_SOURCE=199309L\n")
         file.write("OSHMEM_CC=cc\n")
         file.write("OSHMEM_C_FLAGS=-O3 -g\n")
 
@@ -62,7 +62,7 @@ class Ember(MakefilePackage):
         cc = self.spec["mpi"].mpicc
         cflags = "-O3"
         if not self.spec.satisfies("%nvhpc@:20.11"):
-            cflags = "-O3 -std=c99"
+            cflags = "-O3 -std=c99 -D_POSIX_C_SOURCE=199309L"
         oshmem_cc = "cc"
         oshmem_c_flags = "-O3 -g"
 

--- a/var/spack/repos/builtin/packages/picsarlite/package.py
+++ b/var/spack/repos/builtin/packages/picsarlite/package.py
@@ -49,6 +49,10 @@ class Picsarlite(MakefilePackage):
 
         if "+prod" in self.spec:
             mode = "prod"
+            """ TODO: need to add `-fallow-argument-mismatch` to the other modes if gfortran version is 10 or above
+            """
+            if comp == "gnu" and self.compiler.version >= ver(10):
+                targets.append("FARGS={0}".format("-O3 -fopenmp -JModules -ftree-vectorize -fallow-argument-mismatch"))
         elif "+prod_spectral" in self.spec:
             mode = "prod_spectral"
         elif "+debug" in self.spec:

--- a/var/spack/repos/builtin/packages/thornado-mini/package.py
+++ b/var/spack/repos/builtin/packages/thornado-mini/package.py
@@ -33,9 +33,15 @@ class ThornadoMini(MakefilePackage):
 
         file = open("Makefile", "w")
 
-        file.write(
-            "FORTRAN_mymachine = %s %s\n" % (self.spec["mpi"].mpifc, self.compiler.openmp_flag)
-        )
+        if "gfortran" in self.compiler.fc and self.compiler.version >= ver(10):
+            file.write(
+                "FORTRAN_mymachine = %s %s -fallow-argument-mismatch\n" % (self.spec["mpi"].mpifc, self.compiler.openmp_flag)
+            )
+        else:
+            file.write(
+                "FORTRAN_mymachine = %s %s\n" % (self.spec["mpi"].mpifc, self.compiler.openmp_flag)
+            )
+
         file.write(
             "FLINKER_mymachine = %s %s\n" % (self.spec["mpi"].mpifc, self.compiler.openmp_flag)
         )


### PR DESCRIPTION
There are a number of errors from the sub package themselves. Here, I list the errors and solutions. Some are good, but some are temporary get-arounds.

- miniamr has lots of errors regarding duplicate definitions of variables.
  - Those variables are defined in a header, block.h.
  - The current version referred in ecp-proxy-apps package is 1.6.4 .
  - The later version `1.6.7` adds extern  to each variable definition in block.h .
  - So, the version is set to a master .
- minivite has errors as 'vsz' not specified in enclosing 'parallel' 
  - The current version is 1.0.
  - The fix is to change the version to "develop"
  - The error has to to do with the openmp pragma, parallel for default(none).
    - is changed to default(shared)  in the later version of minivite.
  - OpenMP 4.0 was introduced since gcc 9. It has a different rule regarding shared variables. Previously, if a variable is const, it is considered shared by default, even with no default  behavior defined. [Now with OpenMP 4.0 and beyond, it is no longer the case](https://gcc.gnu.org/gcc-9/porting_to.html#ompdatasharing). it requires either to set the default behavior to shared  or list every one of them in shared() .
- picsarlite and  thornado-mini have gfortran compiler errors regarding argument mismatch.
  - I believe it is the compiler bug specific to gfortran. It can be suppressed via the fortran compiler flag -fallow-argument-mismatch 
  - Spacks interface to the fortran compiler is adding fflags=-fallow-argument-mismatch  at the spack add  command. This was not effective.
  - Tried environment variables and it did not work
    - export FCFLAGS=-fallow-argument-mismatch
    - export FFLAGS=-fallow-argument-mismatch
  - Also tried setting FC, F90 and F77 to mpifc, mpif90 and mpif77 respectively. It did nothing
  - So, I had to edit package.py of picsarlite and tornado-mini to add the flag.
- ember has errors like `error: storage size of a struct timespec variable is unknown`
  - It's build relies on -std=c99 . However, that needs to be -std=gnu99  for gcc.
  - Alternatively, I added -D_POSIX_C_SOURCE=199309L to the compiler flag.